### PR TITLE
Fixed a missing bracket

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ ParticleAccessory.prototype.setState = function(state, callback) {
 	
 	this.log.info("Calling function: " + onUrl);
 	
-	var argument = this.args.replace("{STATE", (state ? "1" : "0"));
+	var argument = this.args.replace("{STATE}", (state ? "1" : "0"));
 
 	request.post(
 		onUrl, {


### PR DESCRIPTION
Line 141 had a missing bracket for the {STATE} replacement, thus causing strange results "0}" or "1}".
